### PR TITLE
Setup pylint and fix violations

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,34 +1,23 @@
 container:
   image: python:3.7
 
-test_task:
-  pip_cache:
-    folder: ~/.cache/pip
-    fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
-    populate_script: pip install black mypy pylint pytest
+pip_cache: &pip_cache
+  folder: ~/.cache/pip
+  fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 2"
+  populate_script: pip install black mypy pylint pytest
 
+test_task:
+  pip_cache: *pip_cache
   test_script: python -m pytest
 
 typecheck_task:
-  pip_cache:
-    folder: ~/.cache/pip
-    fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
-    populate_script: pip install black mypy pylint pytest
-
+  pip_cache: *pip_cache
   test_script: python -m mypy dataclass_structor
 
 formatter_task:
-  pip_cache:
-    folder: ~/.cache/pip
-    fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
-    populate_script: pip install black mypy pylint pytest
-
-  test_script: python -m pylint
+  pip_cache: *pip_cache
+  test_script: python -m black --diff --check dataclass_structor tests
 
 linter_task:
-  pip_cache:
-    folder: ~/.cache/pip
-    fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
-    populate_script: pip install black mypy pylint pytest
-
+  pip_cache: *pip_cache
   test_script: pylint --rcfile=.pylintrc dataclass_structor tests

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ container:
 
 pip_cache: &pip_cache
   folder: ~/.cache/pip
-  fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 2"
+  fingerprint_script: echo $PYTHON_VERSION && echo $CIRRUS_CHANGE_IN_REPO
   populate_script: pip install black mypy pylint pytest
 
 test_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ test_task:
   pip_cache:
     folder: ~/.cache/pip
     fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
-    populate_script: pip install mypy pytest black
+    populate_script: pip install black mypy pylint pytest
 
   test_script: python -m pytest
 
@@ -13,7 +13,7 @@ typecheck_task:
   pip_cache:
     folder: ~/.cache/pip
     fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
-    populate_script: pip install mypy pytest black
+    populate_script: pip install black mypy pylint pytest
 
   test_script: python -m mypy dataclass_structor
 
@@ -21,6 +21,14 @@ formatter_task:
   pip_cache:
     folder: ~/.cache/pip
     fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
-    populate_script: pip install mypy pytest black
+    populate_script: pip install black mypy pylint pytest
 
-  test_script: python -m black --diff --check dataclass_structor tests
+  test_script: python -m pylint
+
+linter_task:
+  pip_cache:
+    folder: ~/.cache/pip
+    fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock && echo "cache version 1"
+    populate_script: pip install black mypy pylint pytest
+
+  test_script: pylint --rcfile=.pylintrc dataclass_structor tests

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,562 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        missing-docstring
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception".
+overgeneral-exceptions=Exception

--- a/.pylintrc
+++ b/.pylintrc
@@ -139,7 +139,8 @@ disable=print-statement,
         deprecated-sys-function,
         exception-escape,
         comprehension-escape,
-        missing-docstring
+        missing-docstring,
+        bad-continuation
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -170,7 +171,7 @@ output-format=text
 reports=no
 
 # Activate the evaluation score.
-score=yes
+score=no
 
 
 [REFACTORING]
@@ -552,7 +553,7 @@ max-returns=6
 max-statements=50
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=0
 
 
 [EXCEPTIONS]

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,11 @@ build-docs:  ## Generate the docs
 check-format: ## Check that the code formatting is up to snuff
 	pipenv run python -m black --diff --check dataclass_structor tests
 
-format:  ## Run the auto formatted against the code
+format:  ## Run the auto formatter against the code
 	pipenv run python -m black dataclass_structor tests
+
+lint:  ## Run the the linter across the code
+	pipenv run pylint --rcfile=.pylintrc dataclass_structor tests
 
 
 .PHONY: typecheck test format perf-tests build-docs check-format

--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,4 @@ format:  ## Run the auto formatter against the code
 lint:  ## Run the the linter across the code
 	pipenv run pylint --rcfile=.pylintrc dataclass_structor tests
 
-
 .PHONY: typecheck test format perf-tests build-docs check-format

--- a/Pipfile
+++ b/Pipfile
@@ -8,12 +8,13 @@ name = "pypi"
 "e1839a8" = {path = ".", editable = true}
 
 [dev-packages]
-pytest = "*"
 black = "*"
 mypy = "*"
+perf = "*"
+pylint = "*"
+pytest = "*"
 sphinx = "*"
 sphinx-autobuild = "*"
-perf = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2cf3bd1461aac0ceb6f1323f68dddfc8ca264e25d29765b8fe14488e9055be40"
+            "sha256": "9cd4225dd1d91c58c1b8493885838ed34e33fd2078c95aa505a7564b9f5b41fd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -46,6 +46,13 @@
                 "sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65"
             ],
             "version": "==0.26.2"
+        },
+        "astroid": {
+            "hashes": [
+                "sha256:39183aecc01d6f74eb54edc6739992e842f3bf3068bdfaaba30b5a1742f44091",
+                "sha256:62bd1d8d2ace3e812b3a22eb3c4b7856536d8cc0cdb37466f6a53cf881dbad1f"
+            ],
+            "version": "==2.2.4"
         },
         "atomicwrites": {
             "hashes": [
@@ -119,12 +126,53 @@
             ],
             "version": "==1.1.0"
         },
+        "isort": {
+            "hashes": [
+                "sha256:89041186651a9a6159683098f337eed0994d9d94e006f891c6e8cbeb8e65f1c7",
+                "sha256:ba51a651505242b0b37ad94b281e1154301e221a40c623e62334ed863fc1c98c"
+            ],
+            "version": "==4.3.12"
+        },
         "jinja2": {
             "hashes": [
                 "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
             "version": "==2.10"
+        },
+        "lazy-object-proxy": {
+            "hashes": [
+                "sha256:0ce34342b419bd8f018e6666bfef729aec3edf62345a53b537a4dcc115746a33",
+                "sha256:1b668120716eb7ee21d8a38815e5eb3bb8211117d9a90b0f8e21722c0758cc39",
+                "sha256:209615b0fe4624d79e50220ce3310ca1a9445fd8e6d3572a896e7f9146bbf019",
+                "sha256:27bf62cb2b1a2068d443ff7097ee33393f8483b570b475db8ebf7e1cba64f088",
+                "sha256:27ea6fd1c02dcc78172a82fc37fcc0992a94e4cecf53cb6d73f11749825bd98b",
+                "sha256:2c1b21b44ac9beb0fc848d3993924147ba45c4ebc24be19825e57aabbe74a99e",
+                "sha256:2df72ab12046a3496a92476020a1a0abf78b2a7db9ff4dc2036b8dd980203ae6",
+                "sha256:320ffd3de9699d3892048baee45ebfbbf9388a7d65d832d7e580243ade426d2b",
+                "sha256:50e3b9a464d5d08cc5227413db0d1c4707b6172e4d4d915c1c70e4de0bbff1f5",
+                "sha256:5276db7ff62bb7b52f77f1f51ed58850e315154249aceb42e7f4c611f0f847ff",
+                "sha256:61a6cf00dcb1a7f0c773ed4acc509cb636af2d6337a08f362413c76b2b47a8dd",
+                "sha256:6ae6c4cb59f199d8827c5a07546b2ab7e85d262acaccaacd49b62f53f7c456f7",
+                "sha256:7661d401d60d8bf15bb5da39e4dd72f5d764c5aff5a86ef52a042506e3e970ff",
+                "sha256:7bd527f36a605c914efca5d3d014170b2cb184723e423d26b1fb2fd9108e264d",
+                "sha256:7cb54db3535c8686ea12e9535eb087d32421184eacc6939ef15ef50f83a5e7e2",
+                "sha256:7f3a2d740291f7f2c111d86a1c4851b70fb000a6c8883a59660d95ad57b9df35",
+                "sha256:81304b7d8e9c824d058087dcb89144842c8e0dea6d281c031f59f0acf66963d4",
+                "sha256:933947e8b4fbe617a51528b09851685138b49d511af0b6c0da2539115d6d4514",
+                "sha256:94223d7f060301b3a8c09c9b3bc3294b56b2188e7d8179c762a1cda72c979252",
+                "sha256:ab3ca49afcb47058393b0122428358d2fbe0408cf99f1b58b295cfeb4ed39109",
+                "sha256:bd6292f565ca46dee4e737ebcc20742e3b5be2b01556dafe169f6c65d088875f",
+                "sha256:cb924aa3e4a3fb644d0c463cad5bc2572649a6a3f68a7f8e4fbe44aaa6d77e4c",
+                "sha256:d0fc7a286feac9077ec52a927fc9fe8fe2fabab95426722be4c953c9a8bede92",
+                "sha256:ddc34786490a6e4ec0a855d401034cbd1242ef186c20d79d2166d6a4bd449577",
+                "sha256:e34b155e36fa9da7e1b7c738ed7767fc9491a62ec6af70fe9da4a057759edc2d",
+                "sha256:e5b9e8f6bda48460b7b143c3821b21b452cb3a835e6bbd5dd33aa0c8d3f5137d",
+                "sha256:e81ebf6c5ee9684be8f2c87563880f93eedd56dd2b6146d8a725b50b7e5adb0f",
+                "sha256:eb91be369f945f10d3a49f5f9be8b3d0b93a4c2be8f8a5b83b0571b8123e0a7a",
+                "sha256:f460d1ceb0e4a5dcb2a652db0904224f367c9b3c1470d5a7683c0480e582468b"
+            ],
+            "version": "==1.3.1"
         },
         "livereload": {
             "hashes": [
@@ -165,6 +213,13 @@
                 "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
             "version": "==1.1.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
         },
         "more-itertools": {
             "hashes": [
@@ -237,6 +292,14 @@
             ],
             "version": "==2.3.1"
         },
+        "pylint": {
+            "hashes": [
+                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
+                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+            ],
+            "index": "pypi",
+            "version": "==2.3.1"
+        },
         "pyparsing": {
             "hashes": [
                 "sha256:66c9268862641abcac4a96ba74506e594c884e3f57690a696d21ad8210ed667a",
@@ -261,9 +324,19 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:0b83c5697aed17a27efbb631a6a3846501375c6e55112a665b210f223fa69629"
+                "sha256:544a0050e76e9b60751c58617fa28c253ad5d23af2e5f0b1c250390bf90bb0df",
+                "sha256:594bf80477a58b6fd53e8b3f24ccf965c25eeeb6e05e4b1fb18c82c2d2090603",
+                "sha256:75e20ca689d0a2bf0c84f0e2028cc68ebef34b213fa66d73c410c53f870c49f4",
+                "sha256:994da68a1dc1050f290f8017f044172360b608c0f2562b47645ecc69d7a61c0a",
+                "sha256:ad902e00088c50bdced94a57b819c24fdadaeaed5494df7a9a67d63774f210fd",
+                "sha256:b11aff75875ffc73541c4e4b1ac2f5e21717c1fc4396238943b9a44d962e74e1",
+                "sha256:bc733b5a9047c3e4848c0e80eeacfa6a799139242606410260c5450d665ea58c",
+                "sha256:d960c68931b96bb215f385baa8ef867b8ebac66af60fa06cc1008f963848c7ad",
+                "sha256:dd461c04e6a91e4eef7d5b75c1fc1c7013d3f8d354033b16526baadddd524079",
+                "sha256:e4d6b5d6218a06f3141189d75c93876dd525a6d15f1b00ef4f274726c93719f1",
+                "sha256:f3c386fa12415bde8a0162745c4badf98fe171c6dfd67e54831f05ec88feeebb"
             ],
-            "version": "==5.1b3"
+            "version": "==5.1b5"
         },
         "requests": {
             "hashes": [
@@ -385,6 +458,7 @@
                 "sha256:d659517ca116e6750101a1326107d3479028c5191f0ecee3c7203c50f5b915b0",
                 "sha256:eddd3fb1f3e0f82e5915a899285a39ee34ce18fd25d89582bc89fc9fb16cd2c6"
             ],
+            "markers": "implementation_name == 'cpython'",
             "version": "==1.3.1"
         },
         "urllib3": {
@@ -399,6 +473,12 @@
                 "sha256:965f658d0732de3188211932aeb0bb457587f04f63ab4c1e33eab878e9de961d"
             ],
             "version": "==0.9.0"
+        },
+        "wrapt": {
+            "hashes": [
+                "sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533"
+            ],
+            "version": "==1.11.1"
         }
     }
 }

--- a/dataclass_structor/structure.py
+++ b/dataclass_structor/structure.py
@@ -2,7 +2,20 @@ import decimal
 import datetime
 import enum
 import uuid
-from typing import get_type_hints, Any, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import (
+    get_type_hints,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Iterable,
+    Optional,
+    Set,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 
 T = TypeVar("T")  # pylint: disable=invalid-name
@@ -86,7 +99,7 @@ def _try_convert_string_to_decimal(value):
         raise ValueError from ex
 
 
-_STRUCTURE_STR_GOAL_TYPE_TO_CONVERSION_MAP = {
+_STRUCTURE_STR_GOAL_TYPE_TO_CONVERSION_MAP: Dict[Type, Callable] = {
     int: int,
     float: float,
     decimal.Decimal: _try_convert_string_to_decimal,
@@ -157,7 +170,7 @@ def _try_structure_tuple(value: Tuple[Any], goal_type: Any) -> Tuple:
 # argument and the "goal type" as the second argument.
 # The order of this list of pairs denotes what order values will be structured
 # by.
-_STRUCTURE_VALUE_CONDITION_CONVERSION_PAIRS = [
+_STRUCTURE_VALUE_CONDITION_CONVERSION_PAIRS: Iterable[Tuple[Callable, Callable]] = [
     (lambda v, gt: isinstance(v, dict), _try_structure_object),
     (lambda v, gt: getattr(gt, "_name", None) == "Tuple", _try_structure_tuple),
     (lambda v, gt: getattr(gt, "_name", None) == "Set", _try_structure_set),

--- a/dataclass_structor/unstructure.py
+++ b/dataclass_structor/unstructure.py
@@ -3,7 +3,7 @@ import datetime
 import enum
 import uuid
 from dataclasses import fields, is_dataclass
-from typing import Any
+from typing import Any, Callable, Iterable, Tuple
 
 
 def unstructure(value: Any) -> Any:
@@ -28,7 +28,7 @@ def unstructure(value: Any) -> Any:
     raise ValueError(f"Could not unstructure: {value}")
 
 
-_UNSTRUCTURE_VALUE_CONDITION_CONVERSION_PAIRS = [
+_UNSTRUCTURE_VALUE_CONDITION_CONVERSION_PAIRS: Iterable[Tuple[Callable, Callable]] = [
     (lambda v: v is None, lambda v: v),
     (lambda v: isinstance(v, str), lambda v: v),
     (lambda v: isinstance(v, float), lambda v: v),

--- a/tests/perf_tests.py
+++ b/tests/perf_tests.py
@@ -1,10 +1,11 @@
-import typing
-import perf
-import decimal
 import datetime
+import decimal
+import typing
+
+import perf  # pylint: disable=import-error
 
 from dataclass_structor import structure, unstructure
-from _fixtures import AnimalEnum, DataClassGuest, SoundsEnum
+from ._fixtures import AnimalEnum, DataClassGuest, SoundsEnum
 
 
 def unstructure_assorted_primatives():
@@ -57,8 +58,8 @@ def structure_dataclass():
     structure({"first_name": "Bobby Jim"}, DataClassGuest)
 
 
-runner = perf.Runner(processes=5)
-benchmark_fns = [
+RUNNER = perf.Runner(processes=5)
+BENCHMARK_FNS = [
     unstructure_assorted_primatives,
     structure_assorted_primatives,
     unstructure_assorted_simple_types,
@@ -70,5 +71,5 @@ benchmark_fns = [
     structure_dataclass,
 ]
 
-for fn in benchmark_fns:
-    runner.bench_func(fn.__name__, fn)
+for fn in BENCHMARK_FNS:
+    RUNNER.bench_func(fn.__name__, fn)

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,5 +1,5 @@
 from dataclass_structor import structure, unstructure
-from _fixtures import AnimalEnum as Animal, SoundsEnum as Sounds
+from ._fixtures import AnimalEnum as Animal, SoundsEnum as Sounds
 
 
 def test_unstructure__animal():

--- a/tests/test_nesting.py
+++ b/tests/test_nesting.py
@@ -3,7 +3,7 @@ import typing
 
 from dataclass_structor import structure, unstructure
 
-from _fixtures import DataClassGuest as Guest
+from ._fixtures import DataClassGuest as Guest
 
 
 @dataclasses.dataclass

--- a/tests/test_simple_dataclass.py
+++ b/tests/test_simple_dataclass.py
@@ -1,6 +1,6 @@
 from dataclass_structor import structure, unstructure
 
-from _fixtures import DataClassGuest as Guest
+from ._fixtures import DataClassGuest as Guest
 
 
 def test_unstructure__guest_with_first_name():

--- a/tests/test_simple_errors.py
+++ b/tests/test_simple_errors.py
@@ -2,10 +2,10 @@ import datetime
 import decimal
 import uuid
 
-import pytest
+import pytest  # pylint: disable=import-error
 
 from dataclass_structor import structure
-from _fixtures import AnimalEnum, SoundsEnum
+from ._fixtures import AnimalEnum, SoundsEnum
 
 
 def test_structure__bad_str__int():

--- a/tests/test_slotted_classes.py
+++ b/tests/test_slotted_classes.py
@@ -1,22 +1,22 @@
 from dataclass_structor import structure, unstructure
-from _fixtures import SlottedGuest as Guest
+from ._fixtures import SlottedGuest
 
 
 def test_unstructure__guest_with_first_name():
     expected = {"first_name": "Bobby Jim"}
-    assert unstructure(Guest(first_name="Bobby Jim")) == expected
+    assert unstructure(SlottedGuest(first_name="Bobby Jim")) == expected
 
 
 def test_structure__guest_with_first_name():
-    expected = Guest(first_name="Bobby Jim")
-    assert structure({"first_name": "Bobby Jim"}, Guest) == expected
+    expected = SlottedGuest(first_name="Bobby Jim")
+    assert structure({"first_name": "Bobby Jim"}, SlottedGuest) == expected
 
 
 def test_unstructure__guest_without_first_name():
     expected = {"first_name": None}
-    assert unstructure(Guest(first_name=None)) == expected
+    assert unstructure(SlottedGuest(first_name=None)) == expected
 
 
 def test_structure__guest_without_first_name():
-    expected = Guest(first_name=None)
-    assert structure({"first_name": None}, Guest) == expected
+    expected = SlottedGuest(first_name=None)
+    assert structure({"first_name": None}, SlottedGuest) == expected


### PR DESCRIPTION
I would sort of like to have linting enforced in this package. Doing it
sooner rather than later will hopefully reduce the noise later on.

In this PR we also deal with all of the linting errors we introduced. Some linting
errors were skipped where it made sense. Some rules were adjusted.

Two files that changed quite a bit was the `structure.py` and
`unstructure.py` files which had many violations. `unstructure.py`
complained about too many returns so it required a significant refactor.