### PR TITLE
Use a better cache key.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ container:
 
 pip_cache: &pip_cache
   folder: ~/.cache/pip
-  fingerprint_script: echo $PYTHON_VERSION && echo $CIRRUS_CHANGE_IN_REPO
+  fingerprint_script: echo $PYTHON_VERSION && cat Pipfile.lock
   populate_script: pip install black mypy pylint pytest
 
 setup_cache_task:


### PR DESCRIPTION
I changed the method of fingerprinting the cache version while trying to
improve it. This commit goes back to the previous method.